### PR TITLE
ACL-Size

### DIFF
--- a/sai/inc/saiacl.h
+++ b/sai/inc/saiacl.h
@@ -119,7 +119,21 @@ typedef enum _sai_acl_table_attr_t
      * (default = 0) - Grow dynamically till MAX ACL TCAM Size
      * By default table can grow upto maximum ACL TCAM space. 
      * Supported only during Table Create for now until NPU 
-     * supports Dynamic adjustment of Table size post Table creation */
+     * supports Dynamic adjustment of Table size post Table creation 
+     *
+     * The table size refers to the number of ACL entries. The number 
+     * of entries that get's allocated when we create a table with a 
+     * specific size would depend on the ACL CAM Arch of the NPU. Some 
+     * NPU supports different blocks, each may have same or different 
+     * size and what gets allocated can depend on the block size or other 
+     * factors. So internally what gets allocated when we do a table 
+     * create would be based on the NPU CAM Arch and size may be more 
+     * than what is requested. As an example the NPU may support blocks of
+     * 128 entries. When a user creates a table of size 100, the actual
+     * size that gets allocated is 128. Hence its recommended that the user
+     * does a get_attribute(SAI_ACL_TABLE_ATTR_SIZE) to query the actual 
+     * table size on table create so the user knows the ACL CAM space 
+     * allocated and able to do ACL CAM Carving accurately */
     SAI_ACL_TABLE_ATTR_SIZE,
 
     /* Match fields [bool] 

--- a/sai/inc/saiacl.h
+++ b/sai/inc/saiacl.h
@@ -115,10 +115,11 @@ typedef enum _sai_acl_table_attr_t
      *  SAI_SWITCH_ATTR_ACL_TABLE_MAXIMUM_PRIORITY] */
     SAI_ACL_TABLE_ATTR_PRIORITY,
 
-    /* Table size [sai_uint32_t]
-     * By default table can grow upto maximum ACL TCAM space. Supported
-     * only during Table Create unless NPU supports Dynamic adjustment 
-     * of Table size post Table creation */
+    /* Table size [sai_uint32_t], CREATE_ONLY 
+     * (default = 0) - Grow dynamically till MAX ACL TCAM Size
+     * By default table can grow upto maximum ACL TCAM space. 
+     * Supported only during Table Create for now until NPU 
+     * supports Dynamic adjustment of Table size post Table creation */
     SAI_ACL_TABLE_ATTR_SIZE,
 
     /* Match fields [bool] 

--- a/sai/inc/saiacl.h
+++ b/sai/inc/saiacl.h
@@ -115,6 +115,12 @@ typedef enum _sai_acl_table_attr_t
      *  SAI_SWITCH_ATTR_ACL_TABLE_MAXIMUM_PRIORITY] */
     SAI_ACL_TABLE_ATTR_PRIORITY,
 
+    /* Table size [sai_uint32_t]
+     * By default table can grow upto maximum ACL TCAM space. Supported
+     * only during Table Create unless NPU supports Dynamic adjustment 
+     * of Table size post Table creation */
+    SAI_ACL_TABLE_ATTR_SIZE,
+
     /* Match fields [bool] 
      * (MANDATORY_ON_CREATE, mandatory to pass at least one field during ACL Table Creation)
      * (CREATE_ONLY, match fields cannot be changed after the table is created) */


### PR DESCRIPTION
Add a new attribute to specify the size of the table. Its optional. Dynamic adjustment of the size depends on NPU support