### PR TITLE
add PFC-related qos maps

### DIFF
--- a/sai/inc/saiqosmaps.h
+++ b/sai/inc/saiqosmaps.h
@@ -67,6 +67,15 @@ typedef enum _sai_qos_map_type_t
     /** Qos Map to set traffic class and color to DSCP */
     SAI_QOS_MAP_TC_AND_COLOR_TO_DOT1P = 0x0000000a,
 
+    /** Qos Map to set traffic class to priority group */
+    SAI_QOS_MAP_TC_TO_PRIORITY_GROUP = 0x0000000b,
+
+    /** Qos Map to set priority group to PFC priority */
+    SAI_QOS_MAP_PRIORITY_GROUP_TO_PFC_PRIORITY = 0x0000000c,
+
+    /** Qos Map to set PFC priority to traffic class */
+    SAI_QOS_MAP_PFC_PRIORITY_TO_TC = 0x0000000d,
+
     /* -- */
     /* Custom range base value */
     SAI_QOS_MAP_CUSTOM_RANGE_BASE = 0x10000000

--- a/sai/inc/saiqosmaps.h
+++ b/sai/inc/saiqosmaps.h
@@ -73,8 +73,8 @@ typedef enum _sai_qos_map_type_t
     /** Qos Map to set priority group to PFC priority */
     SAI_QOS_MAP_PRIORITY_GROUP_TO_PFC_PRIORITY = 0x0000000c,
 
-    /** Qos Map to set PFC priority to traffic class */
-    SAI_QOS_MAP_PFC_PRIORITY_TO_TC = 0x0000000d,
+    /** Qos Map to set PFC priority to queue */
+    SAI_QOS_MAP_PFC_PRIORITY_TO_QUEUE = 0x0000000d,
 
     /* -- */
     /* Custom range base value */

--- a/sai/inc/saitypes.h
+++ b/sai/inc/saitypes.h
@@ -370,6 +370,12 @@ typedef struct _sai_qos_map_params_t
     /* Dot1p value */
     sai_uint8_t dot1p;
 
+    /* PFC priority value */
+    sai_uint8_t prio;
+
+    /* Priority group value */
+    sai_uint8_t pg;
+
     /* Egress port queue UOID is not known at the time of map creation.
      * Using queue index for maps. */
     sai_queue_index_t    queue_index;


### PR DESCRIPTION
SAI_QOS_MAP_TC_TO_PRIORITY_GROUP is used to map incoming traffic to
priority group based on its TC.

SAI_QOS_MAP_PRIORITY_GROUP_TO_PFC_PRIORITY is used to set the priority
for pause frame for congested priority group.

SAI_QOS_MAP_PFC_PRIORITY_TO_TC is used to stop transmit corresponding
TC based on the priority in the received pause frame.