### PR TITLE
Remove switch default trap channel, fd. Make switch default trap grou…

### DIFF
--- a/sai/inc/saihostintf.h
+++ b/sai/inc/saihostintf.h
@@ -279,13 +279,13 @@ typedef enum _sai_hostif_trap_attr_t
     SAI_HOSTIF_TRAP_ATTR_TRAP_PRIORITY,
 
     /** trap channel to use [sai_hostif_trap_channel_t]
-     * (default to SAI_SWITCH_ATTR_DEFAULT_TRAP_CHANNEL) */
+     * (default to SAI_HOSTIF_TRAP_CHANNEL_CB) */
     SAI_HOSTIF_TRAP_ATTR_TRAP_CHANNEL,
 
     /** file descriptor [sai_object_id_t]
      * Valid only when SAI_HOSTIF_TRAP_ATTR_TRAP_CHANNEL == SAI_HOSTIF_TRAP_CHANNEL_FD
      * Must be set before set SAI_HOSTIF_TRAP_ATTR_TRAP_CHANNEL to SAI_HOSTIF_TRAP_CHANNEL_FD 
-     * (default to SAI_SWITCH_ATTR_DEFAULT_TRAP_CHANNEL_FD) */
+     * (default to SAI_NULL_OBJECT_ID) */
     SAI_HOSTIF_TRAP_ATTR_FD,
 
     /** enable trap for a list of SAI ports [sai_object_list_t]
@@ -373,13 +373,13 @@ typedef enum _sai_hostif_user_defined_trap_id_t
 typedef enum _sai_hostif_user_defined_trap_attr_t
 {
     /** trap channel to use [sai_hostif_trap_channel_t]
-     * (default to SAI_SWITCH_ATTR_DEFAULT_TRAP_CHANNEL) */
+     * (default to SAI_HOSTIF_TRAP_CHANNEL_CB) */
     SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_TRAP_CHANNEL,
 
     /** file descriptor [sai_object_id_t]
      * Valid only when SAI_HOSTIF_TRAP_ATTR_TRAP_CHANNEL == SAI_HOSTIF_TRAP_CHANNEL_FD
      * Must be set before set SAI_HOSTIF_TRAP_ATTR_TRAP_CHANNEL to SAI_HOSTIF_TRAP_CHANNEL_FD 
-     * (default to SAI_SWITCH_ATTR_DEFAULT_TRAP_CHANNEL_FD) */
+     * (default to SAI_NULL_OBJECT_ID) */
     SAI_HOSTIF_USER_DEFINED_TRAP_ATTR_FD,
 
 } sai_hostif_user_defined_trap_attr_t;

--- a/sai/inc/saiswitch.h
+++ b/sai/inc/saiswitch.h
@@ -249,6 +249,16 @@ typedef enum _sai_switch_attr_t
     /** switch number of egress buffer pool [sai_uint32_t] */
     SAI_SWITCH_ATTR_EGRESS_BUFFER_POOL_NUM,
 
+    /** Default trap group [sai_object_id_t]
+    * (default value after switch initialization
+    *    SAI_HOSTIF_TRAP_GROUP_ATTR_ADMIN_STATE = true
+    *    SAI_HOSTIF_TRAP_GROUP_ATTR_PRIO = SAI_SWITCH_ATTR_ACL_TABLE_MINIMUM_PRIORITY,
+    *    SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE = 0,
+    *    SAI_HOSTIF_TRAP_GROUP_ATTR_POLICER = SAI_NULL_OBJECT_ID)
+    * The group handle is read only, while the group attributes, such as queue and policer,
+    * may be modified */
+    SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP,
+
     /** READ-WRITE */
 
     /** Switching mode [sai_switch_switching_mode_t]
@@ -332,24 +342,6 @@ typedef enum _sai_switch_attr_t
      * [uint32_t]
      */
     SAI_SWITCH_ATTR_COUNTER_REFRESH_INTERVAL,
-
-    /** Default trap channel [sai_hostif_trap_channel_t]
-     * (default to SAI_HOSTIF_TRAP_CHANNEL_CB) */
-    SAI_SWITCH_ATTR_DEFAULT_TRAP_CHANNEL,
-
-    /** Default file descriptor for SAI_HOSTIF_TRAP_CHANNEL_FD [sai_object_id_t]
-     * Must be set before set SAI_SWITCH_ATTR_DEFAULT_TRAP_CHANNEL to SAI_HOSTIF_TRAP_CHANNEL_FD
-     * (default to SAI_NULL_OBJECT_ID) */
-    SAI_SWITCH_ATTR_DEFAULT_TRAP_CHANNEL_FD,
-
-    /** Default trap group [sai_object_id_t]
-     * (default value after switch initialization
-     *    SAI_HOSTIF_TRAP_GROUP_ATTR_ADMIN_STATE = true
-     *    SAI_HOSTIF_TRAP_GROUP_ATTR_PRIO = SAI_SWITCH_ATTR_ACL_TABLE_MINIMUM_PRIORITY,
-     *    SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE = 0,
-     *    SAI_HOSTIF_TRAP_GROUP_ATTR_POLICER = SAI_NULL_OBJECT_ID)
-     */
-    SAI_SWITCH_ATTR_DEFAULT_TRAP_GROUP,
 
     /** Default Traffic class value, Defalut TC = 0 */
     SAI_SWITCH_ATTR_QOS_DEFAULT_TC,


### PR DESCRIPTION
…p RO

Remove switch default trap channel and FD, that can be managed by host
trap channel and FD attributes
Modify the host trap channel and FD defaults
Modify switch default trap group to be read only. The object handle is
RO. The group attributes are RW, for example modifying the default group
policer and queue