### PR TITLE
Port buffer profile changes

### DIFF
--- a/sai/inc/saiport.h
+++ b/sai/inc/saiport.h
@@ -230,8 +230,8 @@ typedef enum _sai_port_attr_t
     /** Query list of supported port speed in Mbps [sai_u32_list_t] */
     SAI_PORT_ATTR_SUPPORTED_SPEED,
 
-    /** Priority group number [sai_uint32_t] */
-    SAI_PORT_ATTR_PG_NUM,
+    /** Number of Priority groups [sai_uint32_t] */
+    SAI_PORT_ATTR_NUM_PG,
 
     /** list of ingress priority group ID [sai_object_list_t] */
     SAI_PORT_ATTR_PG_ID_LIST,
@@ -436,6 +436,9 @@ typedef enum _sai_port_attr_t
     /** bit vector enable/disable port PFC [sai_uint8_t].
      * Valid from bit 0 to bit 7 */
     SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL,
+
+    /** Buffer profile for port [sai_object_id_t]*/
+    SAI_PORT_ATTR_QOS_BUFFER_PROFILE_ID,
 
     /** User based Meta Data [sai_uint32_t]
      * Value Range SAI_SWITCH_ATTR_PORT_USER_META_DATA_RANGE */


### PR DESCRIPTION
Added missing buffer profile attribute for port.
Modified SAI_PORT_ATTR_PG_NUM to SAI_PORT_ATTR_NUM_PG and also changed comments for better clarity.